### PR TITLE
change variables since settings.main used by manage.py uses DJANGO_*

### DIFF
--- a/docs/installation/from-source.rst
+++ b/docs/installation/from-source.rst
@@ -105,8 +105,8 @@ A minimal example:
     TIME_ZONE=Europe/Berlin
 
     # Application
-    MEDIA_ROOT=/home/wger/media
-    STATIC_ROOT=/home/wger/static
+    DJANGO_MEDIA_ROOT=/home/wger/media
+    DJANGO_STATIC_ROOT=/home/wger/static
 
     # Django Setup
     DJANGO_SETTINGS_MODULE=settings.main


### PR DESCRIPTION
About installing from source:
the [minimal example](https://wger.readthedocs.io/en/latest/installation/from-source.html) suggests in the env:

https://github.com/wger-project/docs/blob/282339e204c0470f47e68bd3e36091347514a249/docs/installation/from-source.rst?plain=1#L107-L109

when using a different user than the suggested new 'wger' user and importing the wger.env for bootstrap command with
`set -a; . /home/<non_default_folder>/wger.env; set +a`
then checking the env:
`manage.py diffsettings | grep MEDIA_ROOT`
shows the value of 'MEDIA_ROOT' (and 'STATIC_ROOT') as not changed from the default used in [settings.main](https://github.com/wger-project/wger/blob/master/settings/main.py).

In settings.main MEDIA_ROOT and STATIC_ROOT are:
```
MEDIA_ROOT = env.str('DJANGO_MEDIA_ROOT', '/home/wger/media')
STATIC_ROOT = env.str('DJANGO_STATIC_ROOT', '/home/wger/static')
```
so `DJANGO_*` is required to overwrite the values.
Running `python manage.py collectstatic` without this change in the env gave me an error since it tried to access the non existent /home/wger folder.

